### PR TITLE
If we've only seen eofs, we should report the error instead of the EOFs

### DIFF
--- a/src/workers.cc
+++ b/src/workers.cc
@@ -836,14 +836,14 @@ void KafkaConsumerConsumeNum::Execute() {
         default:
           // Set the error for any other errors and break
           delete message;
-          if (m_messages.size() == 0) {
+          if (m_messages.size() == eof_event_count) {
             SetErrorBaton(Baton(errorCode));
           }
           looping = false;
           break;
       }
     } else {
-      if (m_messages.size() == 0) {
+      if (m_messages.size() == eof_event_count) {
         SetErrorBaton(b);
       }
       looping = false;


### PR DESCRIPTION
Reporting the error is more important than reporting EOFs. There's also no way to get the errors in this case by retrying a fetch call at the newer offset, as is possible when messages are being returned. So it's important to return the error in this case.